### PR TITLE
transitioned existing methods to take any params

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Docs: [https://developer.nexmo.com/api/account#getAccountBalance](https://develo
 ### Top Up Balance
 
 ```elixir
-Nexmo.Account.top_up("transaction_reference")
+Nexmo.Account.top_up(trx: "transaction_reference")
 ```
 Docs: [https://developer.nexmo.com/api/account#topUpAccountBalance](https://developer.nexmo.com/api/account#topUpAccountBalance?utm_source=DEV_REL&utm_medium=github&utm_campaign=elixir-client-library#topUp-account-balance)
 
@@ -80,14 +80,14 @@ Docs: [https://developer.nexmo.com/api/account#createAPISecret](https://develope
 ### Retrieve one API Secret
 
 ```elixir
-Nexmo.Account.get_secret("secret_id")
+Nexmo.Account.get_secret(secret_id: "secret_id")
 ```
 Docs: [https://developer.nexmo.com/api/account#retrieveAPISecret](https://developer.nexmo.com/api/account#retrieveAPISecret?utm_source=DEV_REL&utm_medium=github&utm_campaign=elixir-client-library#retrieve-api-secret)
 
 ### Revoke an API Secret
 
 ```elixir
-Nexmo.Account.delete_secret("secret_id")
+Nexmo.Account.delete_secret(secret_id: "secret_id")
 ```
 Docs: [https://developer.nexmo.com/api/account#revokeAPISecret](https://developer.nexmo.com/api/account#revokeAPISecret?utm_source=DEV_REL&utm_medium=github&utm_campaign=elixir-client-library#revoke-api-secret)
 
@@ -129,7 +129,11 @@ Docs: [https://developer.nexmo.com/api/number-insight#getNumberInsightAsync](htt
 ### Send an SMS
 
 ```elixir
-Nexmo.Sms.send(YOUR_NUMBER, RECIPIENT_NUMBER, "Hello world")
+Nexmo.Sms.send(
+  from: YOUR_NUMBER, 
+  to: RECIPIENT_NUMBER, 
+  text: "Hello world
+)
 ```
 
 Docs: [https://developer.nexmo.com/api/sms#send-an-sms](https://developer.nexmo.com/api/sms?utm_source=DEV_REL&utm_medium=github&utm_campaign=elixir-client-library#send-an-sms)

--- a/lib/nexmo/account.ex
+++ b/lib/nexmo/account.ex
@@ -13,21 +13,15 @@ defmodule Nexmo.Account do
     Nexmo.Account.get("#{System.get_env("ACCOUNT_API_ENDPOINT")}/get-balance", [], params: params)
   end
 
-  def top_up(trx) do
-    params = [
-      api_key: Nexmo.Config.api_key,
-      api_secret: Nexmo.Config.api_secret
-    ]
-    body = Poison.encode!(%{trx: trx})
+  def top_up(params) do
+    params = Nexmo.Config.merge_credentials(params)
+    body = Poison.encode!(params)
     Nexmo.Account.post("#{System.get_env("ACCOUNT_API_ENDPOINT")}/top-up", body, [], params: params)
   end
 
-  def update(request) do
-    params = [
-      api_key: Nexmo.Config.api_key,
-      api_secret: Nexmo.Config.api_secret
-    ]
-    body = Enum.into(request, %{})
+  def update(params) do
+    params = Nexmo.Config.merge_credentials(params)
+    body = Enum.into(params, %{})
     Nexmo.Account.post("#{System.get_env("ACCOUNT_API_ENDPOINT")}/settings", Poison.encode!(body), [], params: params)
   end
 
@@ -47,15 +41,15 @@ defmodule Nexmo.Account do
     Nexmo.Account.post("#{System.get_env("SECRETS_API_ENDPOINT")}/#{Nexmo.Config.api_key}/secrets", Poison.encode!(body), headers)
   end
 
-  def get_secret(secret_id) do
+  def get_secret(params) do
     credentials = "#{Nexmo.Config.api_key}:#{Nexmo.Config.api_secret}" |> Base.encode64()
     headers = [{"Authorization", "Basic #{credentials}"}]
-    Nexmo.Account.get("#{System.get_env("SECRETS_API_ENDPOINT")}/#{Nexmo.Config.api_key}/secrets/#{secret_id}", headers)  
+    Nexmo.Account.get("#{System.get_env("SECRETS_API_ENDPOINT")}/#{Nexmo.Config.api_key}/secrets/#{params[:secret_id]}", headers)  
   end
 
-  def delete_secret(secret_id) do
+  def delete_secret(params) do
     credentials = "#{Nexmo.Config.api_key}:#{Nexmo.Config.api_secret}" |> Base.encode64()
     headers = [{"Authorization", "Basic #{credentials}"}]
-    Nexmo.Account.delete("#{System.get_env("SECRETS_API_ENDPOINT")}/#{Nexmo.Config.api_key}/secrets/#{secret_id}", headers)
+    Nexmo.Account.delete("#{System.get_env("SECRETS_API_ENDPOINT")}/#{Nexmo.Config.api_key}/secrets/#{params[:secret_id]}", headers)
   end
 end

--- a/lib/nexmo/sms.ex
+++ b/lib/nexmo/sms.ex
@@ -5,18 +5,12 @@ defmodule Nexmo.Sms do
     JSX.decode!(body)
   end
 
-  def send(from, to, text) do
+  def send(params) do
     headers = [
       {"Content-Type", "application/x-www-form-urlencoded"},
       {"Accept", "text/html"}
     ]
-    params = [
-      api_key: Nexmo.Config.api_key,
-      api_secret: Nexmo.Config.api_secret,
-      from: from,
-      to: to,
-      text: text
-    ]
+    params = Nexmo.Config.merge_credentials(params)
     encoded_text = URI.encode_query(params)
     Nexmo.Sms.post(System.get_env("SMS_API_ENDPOINT"), encoded_text, headers)
   end

--- a/test/account/create_secret_test.exs
+++ b/test/account/create_secret_test.exs
@@ -56,7 +56,7 @@ defmodule Nexmo.Account.CreateSecretTest do
       assert "POST" == conn.method
       Plug.Conn.send_resp(conn, 200, Poison.encode!(valid_response))
     end
-    response = Nexmo.Account.create_secret(secret: "example-4PI-Secret")
+    response = Nexmo.Account.create_secret(secret_id: "example-4PI-Secret")
     assert valid_response == elem(response, 1).body
   end
 end

--- a/test/account/delete_secret_test.exs
+++ b/test/account/delete_secret_test.exs
@@ -40,7 +40,7 @@ defmodule Nexmo.Account.DeleteSecretTest do
       assert "DELETE" == conn.method
       Plug.Conn.send_resp(conn, 200, Poison.encode!(valid_response))
     end
-    response = Nexmo.Account.delete_secret("123a-456b-789c-12345d")
+    response = Nexmo.Account.delete_secret(secret_id: "123a-456b-789c-12345d")
     assert valid_response == elem(response, 1).body
   end
 end

--- a/test/account/get_secret_test.exs
+++ b/test/account/get_secret_test.exs
@@ -56,7 +56,7 @@ defmodule Nexmo.Account.GetSecretTest do
       assert "GET" == conn.method
       Plug.Conn.send_resp(conn, 200, Poison.encode!(valid_response))
     end
-    response = Nexmo.Account.get_secret("123a-456b-789c-12345d")
+    response = Nexmo.Account.get_secret(secret_id: "123a-456b-789c-12345d")
     assert valid_response == elem(response, 1).body
   end
 end

--- a/test/account/top_up_test.exs
+++ b/test/account/top_up_test.exs
@@ -37,11 +37,11 @@ defmodule Nexmo.Account.TopUpTest do
   } do
     Bypass.expect bypass, fn conn ->
       assert "/account/top-up" == conn.request_path
-      assert "api_key=a123456&api_secret=b123456" == conn.query_string
+      assert "api_key=a123456&api_secret=b123456&trx=123" == conn.query_string
       assert "POST" == conn.method
       Plug.Conn.send_resp(conn, 200, Poison.encode!(valid_response))
     end
-    response = Nexmo.Account.top_up(123)
+    response = Nexmo.Account.top_up(trx: "123")
     assert valid_response == elem(response, 1).body
   end
 end

--- a/test/account/update_test.exs
+++ b/test/account/update_test.exs
@@ -44,7 +44,7 @@ defmodule Nexmo.Account.UpdateTest do
   } do
     Bypass.expect bypass, fn conn ->
       assert "/account/settings" == conn.request_path
-      assert "api_key=a123456&api_secret=b123456" == conn.query_string
+      assert "api_key=a123456&api_secret=b123456&drCallBackUrl=https%3A%2F%2Fexample.com%2Fdelivery&moCallBackUrl=https%3A%2F%2Fexample.com%2Finbound" == conn.query_string
       assert "POST" == conn.method
       Plug.Conn.send_resp(conn, 200, Poison.encode!(valid_response))
     end

--- a/test/sms/send_test.exs
+++ b/test/sms/send_test.exs
@@ -66,7 +66,7 @@ defmodule Nexmo.Sms.SendTest do
       assert {"content-type", "application/x-www-form-urlencoded"} in conn.req_headers
       Plug.Conn.send_resp(conn, 200, Poison.encode!(valid_response))
     end
-    response = Nexmo.Sms.send(from, to, text)
+    response = Nexmo.Sms.send(from: from, to: to, text: text)
     assert valid_response == elem(response, 1).body
   end
 end


### PR DESCRIPTION
Introduced a more flexible parameter input process when the Number Insight API was brought into the SDK, and now bringing that to the existing API functions. Instead of explicitly defining which parameters it expects to receive, it accepts all parameters, merges them with the credentials stored in the environment variables, and sends them to the API endpoint. This allows for API updates and they won't immediately break functionality in the SDK.